### PR TITLE
Trivial conditional for dtostrf

### DIFF
--- a/LCDWIKI_GUI.h
+++ b/LCDWIKI_GUI.h
@@ -17,7 +17,7 @@
 #endif
 
 
-#if defined(__AVR__) || defined(__arm__)
+#if !defined(CORE_TEENSY) && defined(__arm__)
 #include <avr/dtostrf.h>
 #endif
 

--- a/LCDWIKI_GUI.h
+++ b/LCDWIKI_GUI.h
@@ -7,7 +7,7 @@
 #include "WProgram.h"
 #endif
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(__arm__)
 #include <avr/pgmspace.h>
 #elif defined(ESP8266)
  #include <pgmspace.h>
@@ -17,9 +17,9 @@
 #endif
 
 
-//#if !defined(AVR)
-//#include <avr/dtostrf.h>
-//#endif
+#if defined(__AVR__) || defined(__arm__)
+#include <avr/dtostrf.h>
+#endif
 
 #define LEFT 0
 #define RIGHT 9999


### PR DESCRIPTION
dear lcdwiki,

This is a trivial change.   Most Arduino targets know about pgmspace.h
dtostrf.h is found in slightly different places.

David.